### PR TITLE
Changed field type of 'public' field to boolean.

### DIFF
--- a/solr-core/omeka/conf/schema.xml
+++ b/solr-core/omeka/conf/schema.xml
@@ -94,7 +94,7 @@
     <field name="title" type="text_en" indexed="true" stored="true" multiValued="true" />
     <field name="tag" type="string" indexed="true" stored="true" multiValued="true" />
     <field name="collection" type="string" indexed="true" stored="true" />
-    <field name="public" type="string" indexed="true" stored="true" />
+    <field name="public" type="boolean" indexed="true" stored="true" />
     <field name="featured" type="boolean" indexed="true" stored="true" />
     <field name="itemtype" type="string" indexed="true" stored="true" />
     <field name="resulttype" type="string" indexed="true" stored="true" />


### PR DESCRIPTION
Hi all, 

After updating to v2.2.0 I found that suddenly my searches were returning no results when I thought there should be. Looking into it, I saw that the search query string was using the value "true" for the public field, when the field was being indexed as a string with the value "1" or "0". This caused all searches to return no results. 

Changing the type of the public field to a boolean resolves this issue.  

Does that make sense? Maybe I'm doing something else wrong. 
-Adam