### PR TITLE
Add ACL to limit SolrSearch admin interface to superusers.

### DIFF
--- a/SolrSearchPlugin.php
+++ b/SolrSearchPlugin.php
@@ -17,6 +17,7 @@ class SolrSearchPlugin extends Omeka_Plugin_AbstractPlugin
         'uninstall',
         'upgrade',
         'initialize',
+        'define_acl',
         'define_routes',
         'after_save_record',
         'after_save_item',
@@ -71,6 +72,17 @@ SQL
 
     }
 
+    /**
+     * Hook to define ACL.
+     *
+     * @param array $args Contains: `acl`.
+     */
+    public function hookDefineAcl($args)
+    {
+        $acl = $args['acl'];
+        $acl->addResource('SolrSearch_Admin');
+        $acl->allow('super', 'SolrSearch_Admin');
+    }
 
     /**
      * If upgrading from 1.x, install the new schema.
@@ -285,7 +297,9 @@ SQL
     public function filterAdminNavigationMain($nav)
     {
         $nav[] = array(
-            'label' => __('Solr Search'), 'uri' => url('solr-search/server')
+            'label' => __('Solr Search'),
+            'uri' => url('solr-search/server'),
+            'resource' => 'SolrSearch_Admin'
         );
         return $nav;
     }


### PR DESCRIPTION
We have an Omeka installation for student work where we grant access to our university's students to create items and exhibits. Recently, one of those students changed the settings in the SolrSearch admin interface. We would like to prevent that from happening in the future.

This pull request adds ACL for the SolrSearch_Admin resource which is in turn used to authorize the SolrSearch_AdminController. It only allows access to the resource from superusers. It also uses the resource to control the appearance of the link to the admin interface in the navigation.

We personally have no need for non-superusers to access the SolrSearch admin interface, but I would be willing to alter my pull request if other types need access. If that is still too restrictive, I would appreciate at least adding the resource even if all users are granted authorization. This would still allow me to limit student access through a separate plugin.
