### PR TITLE
Do not optimize Solr index after each add/delete

### DIFF
--- a/SolrSearchPlugin.php
+++ b/SolrSearchPlugin.php
@@ -151,7 +151,6 @@ SQL
             if (!is_null($doc)) {
                 $solr->addDocuments(array($doc));
                 $solr->commit();
-                $solr->optimize();
             }
 
             // If not, remove an existing document.
@@ -159,7 +158,6 @@ SQL
                 try {
                     $solr->deleteById($mgr->getId($record));
                     $solr->commit();
-                    $solr->optimize();
                 } catch (Exception $e) {}
             }
 
@@ -197,7 +195,6 @@ SQL
         $doc = SolrSearch_Helpers_Index::itemToDocument($item);
         $solr->addDocuments(array($doc));
         $solr->commit();
-        $solr->optimize();
 
     }
 
@@ -233,7 +230,6 @@ SQL
             try {
                 $solr->deleteById($id);
                 $solr->commit();
-                $solr->optimize();
             } catch (Exception $e) {}
         }
 
@@ -254,7 +250,6 @@ SQL
         try {
             $solr->deleteById('Item_' . $item['id']);
             $solr->commit();
-            $solr->optimize();
         } catch (Exception $e) {}
 
     }


### PR DESCRIPTION
From https://wiki.apache.org/solr/UpdateXmlMessages :

  An optimize is like a hard commit except that it forces all of the index
  segments to be merged into a single segment first. Depending on the use cases,
  this operation should be performed infrequently (like nightly), if at all,
  since it is very expensive and involves reading and re-writing the entire
  index.  Segments are normally merged over time anyway (as determined by the
  merge policy), and optimize just forces these merges to occur immediately.

This patch removes all calls to optimize() except where it makes sense to have
them (indexAll, deleteAll, hookUninstall)