### PR TITLE
Index all addon records, and allow public addons to the public.

### DIFF
--- a/lib/SolrSearch/Addon/Manager.php
+++ b/lib/SolrSearch/Addon/Manager.php
@@ -219,7 +219,7 @@ class SolrSearch_Addon_Manager
         }
 
         $addon = $this->findAddonForRecord($record);
-        if (!is_null($addon) && $idxr->isRecordIndexed($record, $addon)) {
+        if (!is_null($addon)) {
             $doc = $idxr->indexRecord($record, $addon);
         }
 


### PR DESCRIPTION
We discovered two issues with addon records. First, if a single addon record was created or updated it would only be indexed if it was public. Second, public users could not see addons in the search results. This patch fixes both of those issues. 

The change to `lib/SolrSearch/Addon/Manager.php` will index all addon records regardless to if they are public or not. 

The changes to `lib/SolrSearch/Addon/Indexer.php` make sure that the `public` field is set on the addon record's document, instead of that field always being null. This allows the public to see those records. The `isRecordIndexed` method is changed to `isRecordPublic` to match its new role in setting the `public` field. The `_addFlag` method is removed as it is made redundant to checks against the `public` field.