### PR TITLE
Allow addons to get metadata, and create addon for collections.

### DIFF
--- a/addons/collections.json
+++ b/addons/collections.json
@@ -1,0 +1,25 @@
+{
+    "collections": {
+        "table"       : "Collection",
+        "result_type" : "Collection",
+        "tagged"      : false,
+        "flag"        : "public",
+
+        "fields": [
+            {
+                "field"    : "title",
+                "label"    : "Title",
+                "facet"    : false,
+                "is_title" : true,
+                "metadata" : ["Dublin Core", "Title"]
+            },
+            {
+                "field"    : "description",
+                "label"    : "Description",
+                "facet"    : false,
+                "is_title" : false,
+                "metadata" : ["Dublin Core", "Description"]
+            }
+        ]
+    }
+}

--- a/lib/SolrSearch/Addon/Config.php
+++ b/lib/SolrSearch/Addon/Config.php
@@ -195,12 +195,14 @@ class SolrSearch_Addon_Config
             $field->is_facet = array_key_exists('facet', $json)    ? $json['facet']    : false;
             $field->is_title = array_key_exists('is_title', $json) ? $json['is_title'] : false;
             $field->remote   = array_key_exists('remote', $json)   ? (object) $json['remote'] : null;
+            $field->metadata = array_key_exists('metadata', $json) ? (array) $json['metadata'] : null;
         } else {
             $field->name     = $json;
             $field->label    = $json;
             $field->is_facet = false;
             $field->is_title = false;
             $field->remote   = null;
+            $field->metadata = null;
         }
 
         return $field;

--- a/lib/SolrSearch/Addon/Field.php
+++ b/lib/SolrSearch/Addon/Field.php
@@ -51,15 +51,25 @@ class SolrSearch_Addon_Field
      **/
     var $remote;
 
+    /**
+     * This is an array containing the set and name to a metadata item for
+     * the data in this field.
+     *
+     * @var array|null
+     **/
+    var $metadata;
+
 
     function __construct(
-        $name=null, $label=null, $is_facet=null, $is_title=null, $remote=null
+        $name=null, $label=null, $is_facet=null, $is_title=null, $remote=null,
+        $metadata=null
     ) {
         $this->name     = $name;
         $this->label    = $label;
         $this->is_facet = $is_facet;
         $this->is_title = $is_title;
         $this->remote   = $remote;
+        $this->metadata = $metadata;
     }
 
 

--- a/lib/SolrSearch/Addon/Indexer.php
+++ b/lib/SolrSearch/Addon/Indexer.php
@@ -142,10 +142,12 @@ class SolrSearch_Addon_Indexer
         foreach ($addon->fields as $field) {
             $solrName = $this->makeSolrName($addon, $field->name);
 
-            if (is_null($field->remote)) {
-                $value = $this->getLocalValue($record, $field);
-            } else {
+            if (!is_null($field->remote)) {
                 $value = $this->getRemoteValue($record, $field);
+            } else if (!is_null($field->metadata)) {
+                $value = $this->getMetadataValue($record, $field);
+            } else {
+                $value = $this->getLocalValue($record, $field);
             }
 
             foreach ($value as $v) {
@@ -214,6 +216,24 @@ class SolrSearch_Addon_Indexer
         foreach ($rows as $item) {
             $value[] = $item[$field->name];
         }
+
+        return $value;
+    }
+
+
+    /**
+     * This returns a value that is metadata to the record.
+     *
+     * @param Omeka_Record           $record The record to get the value from.
+     * @param SolrSearch_Addon_Field $field  The field that defines where to get
+     * the value.
+     *
+     * @return mixed $value The value of the field in the record.
+     * @author Eric Rochester <erochest@virginia.edu>
+     **/
+    protected function getMetadataValue($record, $field)
+    {
+        $value = metadata($record, $field->metadata, 'all');
 
         return $value;
     }


### PR DESCRIPTION
We were interested in receiving Collections in our search results along with other addons such as Exhibits and Simple Pages. This pull has a JSON file for Collections, as well as adding support to fetching an addon field as metadata. This is necessary as Collections store their titles and descriptions as Dublin Core metadata fields. 