### PR TITLE
Fixed typo

### DIFF
--- a/SolrSearchPlugin.php
+++ b/SolrSearchPlugin.php
@@ -371,7 +371,7 @@ SQL
     {
         $this->_db
             ->getTable('SolrSearchField')
-            ->installGenericFacet($slub, $label);
+            ->installGenericFacet($slug, $label);
     }
 
 


### PR DESCRIPTION
Hi folks, 

Just a small fix for a typo "slub" which should be "slug". 

The error message I was getting in my local installation for this issue is: Undefined variable: slub in /var/www/html/omeka/digex/plugins/SolrSearch/SolrSearchPlugin.php

-Adam