### PR TITLE
Stricts standards fix for beforeSave

### DIFF
--- a/models/SolrSearchField.php
+++ b/models/SolrSearchField.php
@@ -159,7 +159,7 @@ class SolrSearchField extends Omeka_Record_AbstractRecord
      *
      * @return string The facet label.
      */
-    public function beforeSave()
+    public function beforeSave($args)
     {
         $label = trim($this->label);
         if (empty($label)) $this->label = $this->getOriginalLabel();


### PR DESCRIPTION
Avoid  ``` Error: Declaration of SolrSearchField::beforeSave() should be compatible with Omeka_Record_AbstractRecord::beforeSave() ``` with PHP7